### PR TITLE
Update request dependency to 2.67.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Type <tykelewis@gmail.com>",
   "dependencies": {
     "underscore": "1.4.4",
-    "request": "2.21.0"
+    "request": "2.67.0"
   },
   "devDependencies": {
     "mocha": "1.x",


### PR DESCRIPTION
Older versions of request, including request@2.21.0 uses a vulnerable version of qs according to node security project

<img width="770" alt="screen shot 2015-12-01 at 4 23 06 pm" src="https://cloud.githubusercontent.com/assets/3885959/11517663/24fffb2c-9848-11e5-8fea-b8711bff7dc0.png">

request@2.67.0 has updated that qs dependency and is no longer vulnerable

<img width="801" alt="screen shot 2015-12-01 at 4 23 38 pm" src="https://cloud.githubusercontent.com/assets/3885959/11517673/36c4aac4-9848-11e5-8a4d-0b3009ca7cb0.png">

This upgrade didn't break any of the tests.
